### PR TITLE
(#3) - jPeek mojo for main classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.idea/
 /target/
+/.settings/
+.project
+.classpath
+.factorypath

--- a/README.md
+++ b/README.md
@@ -2,17 +2,29 @@
 
 Add the plugin execution to your `pom.xml`:
 
-```
+```xml
     <plugin>
         <groupId>org.jpeek</groupId>
         <artifactId>jpeek-maven-plugin</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <executions>
             <execution>
                 <goals>
-                    <goal>jpeek-analysis</goal>
+                    <!-- Bound by default to site phase -->
+                    <goal>analyze</goal>
                 </goals>
             </execution>
         </executions>
+        <configuration>
+            <!-- Those are the default values -->
+            <inputDirectory>${project.build.outputDirectory}</inputDirectory>
+            <outputDirectory>${project.build.directory}/jpeek/</outputDirectory>
+        </configuration>
     </plugin>
+```
+
+Or run it from the command-line:
+
+```
+mvn org.jpeek:jpeek-maven-plugin:1.0-SNAPSHOT:analyze
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the plugin execution to your `pom.xml`:
         <executions>
             <execution>
                 <goals>
-                    <!-- Bound by default to site phase -->
+                    <!-- Bound by default to verify phase -->
                     <goal>analyze</goal>
                 </goals>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@ SOFTWARE.
     <url>https://github.com/yegor256/jpeek-maven-plugin</url>
     <inceptionYear>2020</inceptionYear>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
@@ -72,7 +73,32 @@ SOFTWARE.
             <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jpeek</groupId>
+            <artifactId>jpeek</artifactId>
+            <version>0.30.24</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
     <profile>
         <id>qulice</id>

--- a/src/main/java/org/jpeek/plugin/JpeekMojo.java
+++ b/src/main/java/org/jpeek/plugin/JpeekMojo.java
@@ -23,25 +23,62 @@
  */
 package org.jpeek.plugin;
 
+import java.io.File;
+import java.io.IOException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.jpeek.App;
 
 /**
  * {@link org.apache.maven.plugin.AbstractMojo} implementation for jPeek.
  *
  * @since 0.1
- * @todo #1:30min Implement jpeek plugin execution
- *  JpeekMojo must execute jpeek and analyze project files upon build.
- *  Use the jpeek jar from manve repository to execute it with in the
- *  project.
+ * @todo #3:30min Add some tests for this Mojo using AbstractMojoTestCase
+ *  from maven-plugin-testing-harness. A good resource for examples is
+ *  maven-checkstyle-plugin. It has been verified that it works from the
+ *  command line (see README).
+ * @todo #3:30min Add support for analyzing classes in the test directory.
+ *  This should output an analysis most certainly in a different directory
+ *  from the main classes.
  */
-@Mojo(name = "jpeek-analysis", defaultPhase = LifecyclePhase.TEST)
-public class JpeekMojo extends AbstractMojo {
+@Mojo(name = "analyze", defaultPhase = LifecyclePhase.SITE)
+public final class JpeekMojo extends AbstractMojo {
+
+    /**
+     * Specifies the path where to find classes analyzed by jPeek.
+     * @checkstyle MemberNameCheck (3 lines)
+     */
+    @Parameter(property = "jpeek.input", defaultValue = "${project.build.outputDirectory}")
+    private File inputDirectory;
+
+    /**
+     * Specifies the path to save the jPeek output.
+     * @checkstyle MemberNameCheck (3 lines)
+     */
+    @Parameter(property = "jpeek.output", defaultValue = "${project.build.directory}/jpeek/")
+    private File outputDirectory;
+
+    /**
+     * Skip analyze.
+     */
+    @Parameter(property = "jpeek.skip", defaultValue = "false")
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        //method body
+        if (!this.skip) {
+            try {
+                new App(
+                    this.inputDirectory.toPath(),
+                    this.outputDirectory.toPath()
+                ).analyze();
+            } catch (final IOException ex) {
+                throw new MojoExecutionException("Couldn't analyze", ex);
+            }
+        }
     }
 }

--- a/src/main/java/org/jpeek/plugin/JpeekMojo.java
+++ b/src/main/java/org/jpeek/plugin/JpeekMojo.java
@@ -45,7 +45,7 @@ import org.jpeek.App;
  *  This should output an analysis most certainly in a different directory
  *  from the main classes.
  */
-@Mojo(name = "analyze", defaultPhase = LifecyclePhase.SITE)
+@Mojo(name = "analyze", defaultPhase = LifecyclePhase.VERIFY)
 public final class JpeekMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
This is for #3.

I used typical maven naming for goal and configuration attributes, lifecycle binding phase and added some todos.